### PR TITLE
corrected background image to repeat style and cover bottom of page

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -11,6 +11,7 @@
 
 #search-div {
     margin: auto;
+    padding: 20px;
 }
 
 #search-bar{
@@ -109,14 +110,9 @@ img {
 
 body {
   background-image: url("shopYourPantry.png");
-
   background-position: center;
-  background-repeat: no-repeat;
+  background-repeat: repeat;
   background-size: contain;
-  background-color: #FFB600;
 }
 
-body, html {
-    height: 100%;
-}
 


### PR DESCRIPTION
The style that was set before did not allow the background image to cover to the bottom while in mobile responsiveness. 